### PR TITLE
chores: setting firebase emulators (storage, auth)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# firebase tools
+.firebaserc

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,14 @@
+{
+  "storage": {
+    "rules": "storage.rules"
+  },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "ui": {
+      "enabled": true
+    },
+    "singleProjectMode": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@types/firebase": "^3.2.1",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
@@ -1562,6 +1563,16 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/firebase": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/firebase/-/firebase-3.2.1.tgz",
+      "integrity": "sha512-G8XgHMu2jHlElfc2xVNaYP50F0qrqeTCjgeG1v5b4SRwWG4XKC4fCuEdVZuZaMRmVygcnbRZBAo9O7RsDvmkGQ==",
+      "deprecated": "This is a stub types definition for Firebase API (https://www.firebase.com/docs/javascript/firebase). Firebase API provides its own type definitions, so you don't need @types/firebase installed!",
+      "dev": true,
+      "dependencies": {
+        "firebase": "*"
       }
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/firebase": "^3.2.1",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+
+// Craft rules based on data in your Firestore database
+// allow write: if firestore.get(
+//    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
chore: set up Firebase emulators (storage, auth)

Sets up Firebase emulators for storage and auth. This will allow us to run the application locally and test its functionality without having to deploy it to production.

The emulators are configured to use the same environment variables as the production application. This will ensure that the application behaves the same way in both environments.

This change will make it easier to develop and test the application locally. It will also improve the quality of the application by ensuring that it is thoroughly tested before it is deployed to production.