### PR TITLE
feature: securing home route

### DIFF
--- a/src/Auth/index.tsx
+++ b/src/Auth/index.tsx
@@ -2,23 +2,25 @@ import { ReactElement, createContext, useContext, useMemo } from "react";
 import { User } from "firebase/auth";
 
 import { signIn } from "./authentication";
+import useLocalStorage from "../Hooks/useLocalStorage";
 
 interface AuthContextT {
   user: User | null;
-  logIn: (email: string, password: string) => Promise<User | null>;
+  logIn: (email: string, password: string) => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextT>({
   user: null,
-  logIn: () => new Promise((resolve) => resolve(null)),
+  logIn: () => new Promise((resolve) => resolve()),
 });
 
 // thanks to https://blog.logrocket.com/complete-guide-authentication-with-react-router-v6/
 // for the insights
 function AuthProvider({ children }: { children: ReactElement }) {
-  const [user] = [null];
+  const [user, setUser] = useLocalStorage("user", null);
   const logIn = async (email: string, password: string) => {
-    return await signIn(email, password);
+    const user = await signIn(email, password);
+    setUser(user);
   };
 
   const value = useMemo(() => ({ user, logIn }), [user]);

--- a/src/Pages/SignIn.tsx
+++ b/src/Pages/SignIn.tsx
@@ -8,11 +8,11 @@ const initialState = {
 
 export default function SignIn() {
   const [state, setState] = useState(initialState);
-  const { signIn } = useContext(AuthContext);
+  const { logIn } = useContext(AuthContext);
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    signIn(state.email, state.password);
+    logIn(state.email, state.password);
   }
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -4,6 +4,7 @@ import App from "../App";
 import SignIn from "../Pages/SignIn";
 import Home from "../Pages/Home";
 import NotFound from "../Pages/NotFound";
+import ProtectedRoute from "../Components/ProtectedRoute";
 
 const routes: RouteObject[] = [
   {
@@ -17,7 +18,11 @@ const routes: RouteObject[] = [
       },
       {
         path: "",
-        element: <Home />,
+        element: (
+          <ProtectedRoute>
+            <Home />
+          </ProtectedRoute>
+        ),
       },
     ],
   },


### PR DESCRIPTION
feat: secure home route to only allow signed-in users

This commit secures the home route by requiring users to be logged in before they can access it. This is done by using the ProtectedRoute component to wrap the home route.

This will help to protect the home route from unauthorized access and ensure that only signed-in users can see the page.